### PR TITLE
Feature: upstream native error code from move_base

### DIFF
--- a/tangobot_app/app/src/main/cpp/include/move_base_util.h
+++ b/tangobot_app/app/src/main/cpp/include/move_base_util.h
@@ -17,8 +17,8 @@ class MoveBaseNodeExecutor {
         MoveBaseNodeExecutor();
         ~MoveBaseNodeExecutor();
 
-        void Execute(const char* master_uri, const char* host_ip, const char* node_name);
-        void Shutdown();
+        int Execute(const char* master_uri, const char* host_ip, const char* node_name);
+        int Shutdown();
 };
 
 } // namespace move_base_util

--- a/tangobot_app/app/src/main/cpp/src/move_base_jni.cpp
+++ b/tangobot_app/app/src/main/cpp/src/move_base_jni.cpp
@@ -27,9 +27,7 @@ JNIEXPORT jint JNICALL Java_com_ekumen_tangobot_nodes_MoveBaseNode_execute
     env->ReleaseStringUTFChars(node_name_value, node_name);
 
     move_base_util::MoveBaseNodeExecutor moveBaseNodeExecutor;
-    moveBaseNodeExecutor.Execute(master.c_str(), host.c_str(), node.c_str());
-
-    return 0;
+    return moveBaseNodeExecutor.Execute(master.c_str(), host.c_str(), node.c_str());
 }
 
 JNIEXPORT jint JNICALL Java_com_ekumen_tangobot_nodes_MoveBaseNode_shutdown

--- a/tangobot_app/app/src/main/cpp/src/move_base_util.cpp
+++ b/tangobot_app/app/src/main/cpp/src/move_base_util.cpp
@@ -29,7 +29,7 @@ int InitRos(const char* master_uri, const char* host_ip,
     int argc = 3;
     char* master_uri_copy = strdup(master_uri);
     char* host_ip_copy = strdup(host_ip);
-    char* argv[] = {"nothing_important" , master_uri_copy, host_ip_copy};
+    char* argv[] = {"nothing_important", master_uri_copy, host_ip_copy};
 
     log(std::ostringstream()
         << "\nMaster: " << master_uri_copy << "\n"
@@ -51,12 +51,11 @@ MoveBaseNodeExecutor::MoveBaseNodeExecutor() {}
 
 MoveBaseNodeExecutor::~MoveBaseNodeExecutor() {}
 
-void MoveBaseNodeExecutor::Execute(const char* master_uri, const char* host_ip, const char* node_name) {
-    // TODO on rosjava update: use node_name as parameter. In current NativeNodeMain, libname is used.
-    // TODO (2): handle error code using new NativeNodeMain's API.
-    int result = InitRos(master_uri, host_ip, "move_base");
+int MoveBaseNodeExecutor::Execute(const char* master_uri, const char* host_ip,
+                                  const char* node_name) {
+    int result = InitRos(master_uri, host_ip, node_name);
     if (result == ROS_INIT_ERROR) {
-        return;
+        return result;
     }
 
     ros::NodeHandle n;
@@ -65,12 +64,16 @@ void MoveBaseNodeExecutor::Execute(const char* master_uri, const char* host_ip, 
     move_base::MoveBase move_base(tf);
 
     ros::WallRate loop_rate(100);
-    while(ros::ok()) {
+
+    while (ros::ok()) {
         ros::spinOnce();
         loop_rate.sleep();
     }
+
+    return 0;
 }
 
-void MoveBaseNodeExecutor::Shutdown() {}
-
+int MoveBaseNodeExecutor::Shutdown() {
+    return 0;
+}
 }

--- a/tangobot_app/app/src/main/java/com/ekumen/tangobot/nodes/MoveBaseNode.java
+++ b/tangobot_app/app/src/main/java/com/ekumen/tangobot/nodes/MoveBaseNode.java
@@ -1,11 +1,15 @@
 package com.ekumen.tangobot.nodes;
 
 
+import org.apache.commons.logging.Log;
 import org.ros.namespace.GraphName;
+import org.ros.node.ConnectedNode;
 import org.ros.node.NativeNodeMain;
+import org.ros.node.Node;
 
 public class MoveBaseNode extends NativeNodeMain {
     public static final String NODE_NAME = "move_base";
+    private Log log;
 
     public MoveBaseNode() {
         super("move_base_jni");
@@ -21,4 +25,17 @@ public class MoveBaseNode extends NativeNodeMain {
 
     @Override
     protected native int shutdown();
+
+    @Override
+    public void onStart(ConnectedNode connectedNode) {
+        log = connectedNode.getLog();
+        super.onStart(connectedNode);
+    }
+
+    @Override
+    public void onError(Node node, Throwable throwable) {
+        if (super.executeReturnCode != 0 && log != null) {
+            log.error("Execute error code: " + Integer.toString(super.executeReturnCode));
+        }
+    }
 }


### PR DESCRIPTION
This PR creates a simple implementation to upstream native error codes to the application from move_base.

The action taken when an error is issued can be changed in the future; this is to comply with the new `NativeNodeMain` (this would close #4).

