### PR TITLE
Feature: add startup snackbar

### DIFF
--- a/tangobot_app/app/src/main/AndroidManifest.xml
+++ b/tangobot_app/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:configChanges="orientation|screenSize|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/tangobot_app/app/src/main/java/com/ekumen/tangobot/application/MasterChooserSettingsActivity.java
+++ b/tangobot_app/app/src/main/java/com/ekumen/tangobot/application/MasterChooserSettingsActivity.java
@@ -44,7 +44,12 @@ public abstract class MasterChooserSettingsActivity extends AppCompatPreferenceA
 
     protected SettingsPreferenceFragment mSettingsPreferenceFragment;
     protected SharedPreferences mSharedPref;
-    private static boolean masterConnectionAttempted;
+
+    /**
+     * False if the application hasn't executed {@link #onBackPressed()} during this session
+     * (i.e., settings weren't applied yet), false otherwise.
+     */
+    private static boolean settingsApplied = false;
 
     /**
      * A preference value change listener that updates the preference's summary
@@ -146,11 +151,12 @@ public abstract class MasterChooserSettingsActivity extends AppCompatPreferenceA
 
     @Override
     public void onBackPressed() {
-        // Try to connect to Master by default when this activity wasn't launched by a user.
-        boolean userForcedLaunch = getIntent().getBooleanExtra("user_forced_launch", false);
-        if (!userForcedLaunch) {
+        // Attempt master connection only on first run of this activity.
+        if (!settingsApplied) {
             masterConnectionAttemptSetup();
+            settingsApplied = true;
         }
+
         super.onBackPressed();
     }
 
@@ -164,11 +170,10 @@ public abstract class MasterChooserSettingsActivity extends AppCompatPreferenceA
             String uri = mSharedPref.getString(getResources().getString(R.string.pref_master_uri_key), "");
             intent.putExtra("ROS_MASTER_URI", uri);
         }
-        masterConnectionAttempted = true;
         setResult(RESULT_OK, intent);
     }
 
-    protected boolean masterConnectionWasAttempted() {
-        return masterConnectionAttempted;
+    protected boolean settingsWereAppliedThisSession() {
+        return settingsApplied;
     }
 }

--- a/tangobot_app/app/src/main/java/com/ekumen/tangobot/application/SettingsActivity.java
+++ b/tangobot_app/app/src/main/java/com/ekumen/tangobot/application/SettingsActivity.java
@@ -19,6 +19,7 @@ package com.ekumen.tangobot.application;
 import android.content.SharedPreferences;
 import android.support.design.widget.Snackbar;
 import android.view.View;
+import android.widget.Toast;
 
 
 public class SettingsActivity extends MasterChooserSettingsActivity {
@@ -27,12 +28,36 @@ public class SettingsActivity extends MasterChooserSettingsActivity {
         if (key == getString(R.string.pref_master_is_local_key) ||
                 key == getString(R.string.pref_master_uri_key)) {
 
-            if (masterConnectionWasAttempted() && mSettingsPreferenceFragment.getView() != null) {
-                Snackbar snackbar = Snackbar.make(mSettingsPreferenceFragment.getView(), getString(R.string.snackbar_text_restart), Snackbar.LENGTH_INDEFINITE);
+            if (settingsWereAppliedThisSession() && mSettingsPreferenceFragment.getView() != null) {
+                Snackbar snackbar = Snackbar.make(mSettingsPreferenceFragment.getView(),
+                        getString(R.string.snackbar_text_restart), Snackbar.LENGTH_INDEFINITE);
                 View snackBarView = snackbar.getView();
                 snackBarView.setBackgroundColor(getResources().getColor(android.R.color.holo_orange_dark));
                 snackbar.show();
             }
+        }
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (!settingsWereAppliedThisSession()) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    Toast.makeText(getApplicationContext(), R.string.welcome_text_first_run, Toast.LENGTH_LONG).show();
+                }
+            });
+
+            Snackbar snackbar = Snackbar.make(mSettingsPreferenceFragment.getView(),
+                    getString(R.string.snackbar_text_first_run), Snackbar.LENGTH_INDEFINITE);
+            snackbar.setAction(getString(R.string.snackbar_action_text_first_run), new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    onBackPressed();
+                }
+            });
+            snackbar.show();
         }
     }
 }

--- a/tangobot_app/app/src/main/res/values/strings.xml
+++ b/tangobot_app/app/src/main/res/values/strings.xml
@@ -26,4 +26,9 @@
     <string name="pref_use_same_config_next_time_title">Show settings on startup</string>
     <string name="pref_show_settings_on_startup_key">pref_show_settings_on_startup</string>
     <string name="pref_show_settings_on_startup_summary">Enable to show this screen next time</string>
+
+    <!-- Settings texts -->
+    <string name="welcome_text_first_run">Welcome to Tangobot app! Please define your settings to continue.</string>
+    <string name="snackbar_text_first_run">Click DONE to start after your settings are ready</string>
+    <string name="snackbar_action_text_first_run">Done</string>
 </resources>


### PR DESCRIPTION
Adding snackbar for the first time a user enters settings to start the robot.
-Small fix to allow device orientation changes.

Solves #61.

![screenshot_2017-03-31-15-29-41](https://cloud.githubusercontent.com/assets/2480899/24564378/0979a4d4-1628-11e7-9059-2718092ce812.png)