### PR TITLE
Enable tangobot to publish color camera

### DIFF
--- a/tangobot_app/app/src/main/res/raw/tango_node_params.yaml
+++ b/tangobot_app/app/src/main/res/raw/tango_node_params.yaml
@@ -1,1 +1,2 @@
 publish_device_pose: true
+publish_color_camera: true


### PR DESCRIPTION
Tangobot app was modified to make it possible to get tango color camera data, as requested by @adamantivm . /cc @basicNew to take a look this pull request.